### PR TITLE
Fix missing .js extension

### DIFF
--- a/Experience/Preloader.js
+++ b/Experience/Preloader.js
@@ -1,9 +1,9 @@
 import * as THREE from 'three'
 import GSAP from 'gsap'
 import { EventEmitter } from 'events'
-import convert from './Utils/convertDivsToSpans'
+import convert from './Utils/convertDivsToSpans.js'
 
-import Experience from "./Experience"
+import Experience from "./Experience.js"
 
 export default class Preloader extends EventEmitter {
   constructor() {


### PR DESCRIPTION
## Summary
- add missing `.js` extension in Preloader imports

## Testing
- `npm run build --silent`

------
https://chatgpt.com/codex/tasks/task_b_685ba52cd3f8832e99f8262c68f1597c